### PR TITLE
Add Vite types reference for TextFX demo

### DIFF
--- a/demos/palm/web/textfx/src/vite-env.d.ts
+++ b/demos/palm/web/textfx/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+


### PR DESCRIPTION
## Summary
- add `vite-env.d.ts` file so TypeScript resolves `vite/client`
- run `npm install` to pull in Vite type definitions

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68753047798c8320be4f4fe1a504b0cb