### PR TITLE
Enable Catalan output in TextFX

### DIFF
--- a/demos/palm/web/textfx/src/lib/priming.js
+++ b/demos/palm/web/textfx/src/lib/priming.js
@@ -18,8 +18,13 @@
 // NOTE: The prefix delimiter should not occur anywhere in the example value that follows a prefix
 export const PREFIX_DELIMITER = ':'
 
+// Instruct the language model to reply in Catalan by default
+export const LANGUAGE_INSTRUCTION = 'Totes les respostes han de ser en català.'
+
 export const constructPrompt = (promptComponents, inputs) => {
   const lines = []
+  // Include the default language instruction first
+  lines.push(LANGUAGE_INSTRUCTION)
   if (promptComponents.preamble) {
     lines.push(promptComponents.preamble)
   }


### PR DESCRIPTION
## Summary
- instruct prompts to reply in Catalan by default

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6875998e6b0c8320beff1c847c7b7fb3